### PR TITLE
Improve login feedback

### DIFF
--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -62,8 +62,12 @@ export const LoginPage: React.FC = () => {
         reset({ email: data.email });
       } else {
         // New user - send password to email
-        await sendPasswordToEmail(data.email, true);
-        setStep('password-sent');
+        const sent = await sendPasswordToEmail(data.email, true);
+        if (sent) {
+          setStep('password-sent');
+        } else {
+          setError('root', { message: 'Failed to send password email. Please try again.' });
+        }
       }
     } catch (error) {
       setError('root', { message: 'An error occurred. Please try again.' });
@@ -105,8 +109,12 @@ export const LoginPage: React.FC = () => {
   const handleForgotPassword = async () => {
     setLoading(true);
     try {
-      await sendPasswordToEmail(userEmail, false);
-      setStep('password-sent');
+      const sent = await sendPasswordToEmail(userEmail, false);
+      if (sent) {
+        setStep('password-sent');
+      } else {
+        setError('root', { message: 'Failed to send password reset email.' });
+      }
     } catch (error) {
       setError('root', { message: 'Failed to send password reset email.' });
     } finally {

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -100,6 +100,14 @@ const mockUsers: User[] = [
       totalEmi: 0,
       hasCreditCards: 'no'
     }
+  },
+  {
+    id: '4',
+    email: 'antriksh.tewari89@gmail.com',
+    name: 'Antriksh Tewari',
+    isAdmin: false,
+    createdAt: '2024-01-20T00:00:00Z',
+    isActive: true
   }
 ];
 


### PR DESCRIPTION
## Summary
- improve messaging when sending login email fails
- show errors on forgot-password flow
- add demo user `antriksh.tewari89@gmail.com` in mock database

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684530ab28c8832e96af1f325a63620a