### PR TITLE
Fix password email redirects

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { ComparePage } from './pages/ComparePage';
 import { CardDetailsPage } from './pages/CardDetailsPage';
 import { AdminPage } from './pages/AdminPage';
 import { LoginPage } from './pages/LoginPage';
+import { ResetPasswordPage } from './pages/ResetPasswordPage';
 import { ProtectedRoute } from './components/ProtectedRoute';
 
 function App() {
@@ -19,8 +20,9 @@ function App() {
           <Route path="/onboarding" element={<OnboardingPage />} />
           <Route path="/compare" element={<ComparePage />} />
           <Route path="/card/:id" element={<CardDetailsPage />} />
-          <Route 
-            path="/admin" 
+          <Route path="/reset-password" element={<ResetPasswordPage />} />
+          <Route
+            path="/admin"
             element={
               <ProtectedRoute adminOnly>
                 <AdminPage />

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -62,8 +62,12 @@ export const LoginPage: React.FC = () => {
         reset({ email: data.email });
       } else {
         // New user - send password to email
-        await sendPasswordToEmail(data.email, true);
-        setStep('password-sent');
+        const sent = await sendPasswordToEmail(data.email, true);
+        if (sent) {
+          setStep('password-sent');
+        } else {
+          setError('root', { message: 'Failed to send password email. Please try again.' });
+        }
       }
     } catch (error) {
       setError('root', { message: 'An error occurred. Please try again.' });
@@ -105,8 +109,12 @@ export const LoginPage: React.FC = () => {
   const handleForgotPassword = async () => {
     setLoading(true);
     try {
-      await sendPasswordToEmail(userEmail, false);
-      setStep('password-sent');
+      const sent = await sendPasswordToEmail(userEmail, false);
+      if (sent) {
+        setStep('password-sent');
+      } else {
+        setError('root', { message: 'Failed to send password reset email.' });
+      }
     } catch (error) {
       setError('root', { message: 'Failed to send password reset email.' });
     } finally {

--- a/src/pages/ResetPasswordPage.tsx
+++ b/src/pages/ResetPasswordPage.tsx
@@ -1,0 +1,84 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { supabase } from '../supabaseClient';
+
+const schema = z.object({
+  password: z.string().min(6, 'Password must be at least 6 characters'),
+  confirmPassword: z.string(),
+}).refine((data) => data.password === data.confirmPassword, {
+  message: "Passwords don't match",
+  path: ['confirmPassword'],
+});
+
+export const ResetPasswordPage: React.FC = () => {
+  const navigate = useNavigate();
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+  const { register, handleSubmit, formState: { errors } } = useForm({ resolver: zodResolver(schema) });
+
+  const onSubmit = async (data: any) => {
+    setLoading(true);
+    const { error } = await supabase.auth.updateUser({ password: data.password });
+    if (error) {
+      setError('Failed to update password. Please try again.');
+    } else {
+      navigate('/login');
+    }
+    setLoading(false);
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center py-12">
+      <div className="container mx-auto px-4 max-w-md">
+        <div className="bg-white rounded-xl shadow-card p-8">
+          <h1 className="text-2xl font-bold mb-6 text-center">Set New Password</h1>
+          <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                Password
+              </label>
+              <input
+                {...register('password')}
+                type="password"
+                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                placeholder="New password"
+              />
+              {errors.password && (
+                <p className="text-error-500 text-sm mt-1">{errors.password.message}</p>
+              )}
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                Confirm Password
+              </label>
+              <input
+                {...register('confirmPassword')}
+                type="password"
+                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                placeholder="Confirm password"
+              />
+              {errors.confirmPassword && (
+                <p className="text-error-500 text-sm mt-1">{errors.confirmPassword.message}</p>
+              )}
+            </div>
+            {error && (
+              <div className="bg-error-50 border border-error-200 rounded-lg p-4">
+                <p className="text-error-700 text-sm">{error}</p>
+              </div>
+            )}
+            <button
+              type="submit"
+              disabled={loading}
+              className="w-full bg-gradient-to-r from-primary-600 to-accent-600 text-white py-3 px-4 rounded-lg font-medium hover:shadow-glow transition-all disabled:opacity-50"
+            >
+              {loading ? 'Saving...' : 'Update Password'}
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- add dynamic redirect for supabase password emails
- include redirect when signing up users
- add ResetPasswordPage and route
- use new redirect in admin password reset

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684530ab28c8832e96af1f325a63620a